### PR TITLE
Feat : 유저정보조회, 인게임정보 페이지네이션 제외 구현 완료

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -6,32 +6,23 @@ import { ChartProps } from '../interfaces/UserInfoTypes'
 const Chart = ({ chartData, label }: ChartProps) => {
   ChartJS.register(ArcElement, Tooltip, Legend)
 
+  const theme = useTheme()
+
   const LabelArr = Object.keys(chartData)
   const dataArr = Object.values(chartData)
+  const colors =
+    dataArr.length === 6
+      ? [theme.green.basic, theme.gray.DE, theme.green.neon, theme.color.yellow, theme.color.blue, theme.color.orange]
+      : [theme.green.name, theme.gray.DE, theme.green.basic, theme.green.dark]
 
-  const theme = useTheme()
   const data = {
     labels: LabelArr && LabelArr,
     datasets: [
       {
         label,
         data: dataArr && dataArr,
-        backgroundColor: [
-          theme.green.basic,
-          theme.gray.DE,
-          theme.green.neon,
-          theme.color.yellow,
-          theme.color.blue,
-          theme.color.orange,
-        ],
-        borderColor: [
-          theme.green.basic,
-          theme.gray.DE,
-          theme.green.neon,
-          theme.color.yellow,
-          theme.color.blue,
-          theme.color.orange,
-        ],
+        backgroundColor: colors,
+        borderColor: colors,
         borderWidth: 1,
       },
     ],

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
 import { styled } from 'styled-components'
+import { v4 as uuid } from 'uuid'
 import { BadgeProps } from '../../interfaces/CommonTypes'
 
 // ! [props]
 // * $category : response로 오는 array를 map으로 처리한 string값
 
 const Badge = ({ $category }: BadgeProps) => {
-  let swearWord = ''
+  const uniqueId: string = uuid()
 
-  if ($category === 'fWord') swearWord = '쌍욕'
-  else if ($category === 'aversion') swearWord = '혐오성 발언'
-  else if ($category === 'adHominem') swearWord = '인신공격'
-  else if ($category === 'sHarassment') swearWord = '성희롱'
-  else if ($category === 'immorality') swearWord = '패드립'
-  else swearWord = '기타'
-
-  return <CommonBadge $category={$category}>{swearWord}</CommonBadge>
+  return $category.split(', ').map((item) => (
+    <CommonBadge key={uniqueId + item} $category={item.replaceAll(',', '')}>
+      {item}
+    </CommonBadge>
+  ))
 }
 
 export default Badge
@@ -27,28 +25,29 @@ const CommonBadge = styled.button<BadgeProps>`
   font-weight: 700;
   border-radius: 3px;
   cursor: default;
+  color: white;
   ${({ $category, theme }) => {
     switch ($category) {
-      case 'fWord':
+      case '쌍욕':
         return `border: 1px solid ${theme.color.orange}; color: ${theme.color.orange};`
         break
-      case 'aversion':
+      case '혐오성 발언':
         return `border: 1px solid ${theme.color.blue}; color: ${theme.color.blue};`
         break
-      case 'adHominem':
+      case '인신공격':
         return `border: 1px solid ${theme.color.yellow}; color: ${theme.color.yellow};`
         break
-      case 'sHarassment':
+      case '성희롱':
         return `border: 1px solid ${theme.green.neon}; color: ${theme.green.neon};`
         break
-      case 'immorality':
+      case '패드립':
         return `border: 1px solid ${theme.green.basic}; color: ${theme.green.basic};`
         break
-      case 'etc':
+      case '기타':
         return `border: 1px solid ${theme.gray.DE}; color: ${theme.gray.DE};`
         break
       default:
-        return ''
+        return `color: ${theme.gray.TT};`
     }
   }}
 `

--- a/src/components/common/Image.tsx
+++ b/src/components/common/Image.tsx
@@ -11,6 +11,7 @@ import { errorImg } from '../../assets'
 
 const Image = ({ width, height, $border, src, alt, $zoom = 'off' }: ImgProps) => {
   const [toggleZoom, setToggleZoom] = useState(false)
+  const [imgSrc, setImgSrc] = useState(src || errorImg)
 
   const onZoomClickHandler = () => setToggleZoom(!toggleZoom)
 
@@ -20,10 +21,11 @@ const Image = ({ width, height, $border, src, alt, $zoom = 'off' }: ImgProps) =>
         width={width}
         height={height}
         $border={$border}
-        src={src || errorImg}
+        src={imgSrc}
         alt={alt || `${src} image`}
         $zoom={$zoom}
         onClick={$zoom !== 'off' ? onZoomClickHandler : undefined}
+        onError={() => setImgSrc(errorImg)}
       />
       {toggleZoom && <Portal type={'ZoomImg'} onclick={onZoomClickHandler} src={src} />}
     </>

--- a/src/components/common/ReportList.tsx
+++ b/src/components/common/ReportList.tsx
@@ -49,10 +49,7 @@ const ReportList = ({ reportlist }: ReportListProps) => {
               <span>
                 <strong>{'욕 카테고리'}</strong>
               </span>
-              {/* // TODO DB에 데이터 넣어주면 해당 res값 반영해서 처리 */}
-              {/* {list.cussWord.map((words) => (
-                <Badge key={uniqueId + words} $category={words} />
-              ))} */}
+              <Badge $category={list.category} />
             </div>
             <div>
               <span>

--- a/src/components/common/Tier.tsx
+++ b/src/components/common/Tier.tsx
@@ -12,7 +12,7 @@ const Tier = ({ $tier, $rank }: TierProps) => {
 
   return (
     <CommonTier type={'button'} $tier={$tier}>
-      {userTier}
+      {userTier || '언랭'}
     </CommonTier>
   )
 }
@@ -59,7 +59,7 @@ const CommonTier = styled.button<TierProps>`
         return theme.rank.ch
         break
       default:
-        return ''
+        return theme.gray.SF
     }
   }};
 `

--- a/src/components/modal/Ingame.tsx
+++ b/src/components/modal/Ingame.tsx
@@ -10,6 +10,27 @@ import { getIngame } from '../../axios/userInfo'
 const Ingame = ({ nickname, onclick }: PotalProps) => {
   const { data, isLoading, error } = useQuery(['getIngame'], () => getIngame(nickname && nickname))
 
+  const renderUser = (user: IngameType, position: number) => (
+    <div key={user.championId}>
+      <Image width={50} height={50} $border={5} src={user.championImageUrl} />
+      <EachUserDiv>
+        <p>{user.summonerName}</p>
+        {user.reportsData ? (
+          <>
+            <span>{position === 100 ? '전과있음' : `전과 ${user.reportsData.reportCount}범`}</span>
+            {position !== 100 && <Badge $category={user.reportsData.category} />}
+          </>
+        ) : (
+          <>
+            <span>{'모범시민'}</span>
+            <Image width={13} height={18} src={exampleUserIcon} />
+          </>
+        )}
+      </EachUserDiv>
+      <Tier $tier={user.tierInfo.tier} $rank={user.tierInfo.rank} />
+    </div>
+  )
+
   return (
     <BackgroundDiv>
       <ContentDiv>
@@ -66,54 +87,14 @@ const Ingame = ({ nickname, onclick }: PotalProps) => {
 
               <MatchInfoSection>
                 <UserListDiv $position={'left'}>
-                  {data.participants.map(
-                    (user: IngameType) =>
-                      user.teamId === 100 && (
-                        <div key={user.championId}>
-                          <Image width={50} height={50} $border={5} src={user.championImageUrl} />
-                          <EachUserDiv>
-                            <p>{user.summonerName}</p>
-                            {user.reportsData ? (
-                              <>
-                                <span>{'전과있음'}</span>
-                                <Image width={13} height={18} src={exampleUserIcon} />
-                              </>
-                            ) : (
-                              <>
-                                <span>{'모범시민'}</span>
-                                <Image width={13} height={18} src={exampleUserIcon} />
-                              </>
-                            )}
-                          </EachUserDiv>
-                          <Tier $tier={user.tierInfo.tier} $rank={user.tierInfo.rank} />
-                        </div>
-                      ),
-                  )}
+                  {data.participants
+                    .filter((user: IngameType) => user.teamId === 100)
+                    .map((user: IngameType) => renderUser(user, 100))}
                 </UserListDiv>
                 <UserListDiv $position={'right'}>
-                  {data.participants.map(
-                    (user: IngameType) =>
-                      user.teamId === 200 && (
-                        <div key={user.championId}>
-                          <Image width={50} height={50} $border={5} src={user.championImageUrl} />
-                          <EachUserDiv>
-                            <p>{user.summonerName}</p>
-                            {user.reportsData && user.summonerName === user.reportsData.summonerName ? (
-                              <>
-                                <span>{`전과 ${user.reportsData.reportCount}범`}</span>
-                                <Badge $category={user.reportsData.category} />
-                              </>
-                            ) : (
-                              <>
-                                <span>{'모범시민'}</span>
-                                <Image width={13} height={18} src={exampleUserIcon} />
-                              </>
-                            )}
-                          </EachUserDiv>
-                          <Tier $tier={user.tierInfo.tier} $rank={user.tierInfo.rank} />
-                        </div>
-                      ),
-                  )}
+                  {data.participants
+                    .filter((user: IngameType) => user.teamId === 200)
+                    .map((user: IngameType) => renderUser(user, 200))}
                 </UserListDiv>
               </MatchInfoSection>
             </>

--- a/src/components/modal/Ingame.tsx
+++ b/src/components/modal/Ingame.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query'
-import { AxiosError } from 'axios'
 import { styled } from 'styled-components'
 import { PotalProps } from '../../interfaces/CommonTypes'
 import { UserListDivProps } from '../../interfaces/ModalTypes'
@@ -15,9 +14,37 @@ const Ingame = ({ nickname, onclick }: PotalProps) => {
     <BackgroundDiv>
       <ContentDiv>
         {isLoading ? (
-          <h1>{'Loading'}</h1>
+          <>
+            <GameInfoSection>
+              <div>
+                <h1>{'인게임 정보'}</h1>
+              </div>
+              <button type={'button'} onClick={onclick}>
+                <Image src={closeIcon} />
+              </button>
+            </GameInfoSection>
+            <MatchInfoSection>
+              <ErrorDiv>
+                <h1>{'L O A D I N G . . .'}</h1>
+              </ErrorDiv>
+            </MatchInfoSection>
+          </>
         ) : error ? (
-          <h1>{'error'}</h1>
+          <>
+            <GameInfoSection>
+              <div>
+                <h1>{'인게임 정보'}</h1>
+              </div>
+              <button type={'button'} onClick={onclick}>
+                <Image src={closeIcon} />
+              </button>
+            </GameInfoSection>
+            <MatchInfoSection>
+              <ErrorDiv>
+                <h1>{'진행 중인 게임이 없습니다.'}</h1>
+              </ErrorDiv>
+            </MatchInfoSection>
+          </>
         ) : (
           data && (
             <>
@@ -27,7 +54,7 @@ const Ingame = ({ nickname, onclick }: PotalProps) => {
                   <div>
                     <p>{data.gameMode}</p>
                     <p>{'|'}</p>
-                    <p>{data.gameType}</p>
+                    <p>{data.gameName}</p>
                     <p>{'|'}</p>
                     <p>{data.gameLength}</p>
                   </div>
@@ -42,13 +69,21 @@ const Ingame = ({ nickname, onclick }: PotalProps) => {
                   {data.participants.map(
                     (user: IngameType) =>
                       user.teamId === 100 && (
-                        <div>
+                        <div key={user.championId}>
                           <Image width={50} height={50} $border={5} src={user.championImageUrl} />
                           <EachUserDiv>
-                            {/* // TODO 신고데이터 있을 경우 */}
                             <p>{user.summonerName}</p>
-                            <span>{'모범시민'}</span>
-                            <Image width={13} height={18} src={exampleUserIcon} />
+                            {user.reportsData ? (
+                              <>
+                                <span>{'전과있음'}</span>
+                                <Image width={13} height={18} src={exampleUserIcon} />
+                              </>
+                            ) : (
+                              <>
+                                <span>{'모범시민'}</span>
+                                <Image width={13} height={18} src={exampleUserIcon} />
+                              </>
+                            )}
                           </EachUserDiv>
                           <Tier $tier={user.tierInfo.tier} $rank={user.tierInfo.rank} />
                         </div>
@@ -59,13 +94,21 @@ const Ingame = ({ nickname, onclick }: PotalProps) => {
                   {data.participants.map(
                     (user: IngameType) =>
                       user.teamId === 200 && (
-                        <div>
+                        <div key={user.championId}>
                           <Image width={50} height={50} $border={5} src={user.championImageUrl} />
                           <EachUserDiv>
-                            {/* // TODO 신고데이터 있을 경우 */}
                             <p>{user.summonerName}</p>
-                            <span>{'모범시민'}</span>
-                            <Image width={13} height={18} src={exampleUserIcon} />
+                            {user.reportsData && user.summonerName === user.reportsData.summonerName ? (
+                              <>
+                                <span>{`전과 ${user.reportsData.reportCount}범`}</span>
+                                <Badge $category={user.reportsData.category} />
+                              </>
+                            ) : (
+                              <>
+                                <span>{'모범시민'}</span>
+                                <Image width={13} height={18} src={exampleUserIcon} />
+                              </>
+                            )}
                           </EachUserDiv>
                           <Tier $tier={user.tierInfo.tier} $rank={user.tierInfo.rank} />
                         </div>
@@ -151,6 +194,18 @@ const MatchInfoSection = styled.section`
     border-radius: 10px;
   }
 `
+
+const ErrorDiv = styled.section`
+  width: 100%;
+  height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  h1 {
+    color: ${({ theme }) => theme.gray.AE};
+  }
+`
+
 const UserListDiv = styled.div<UserListDivProps>`
   display: flex;
   flex-direction: column;

--- a/src/interfaces/CommonTypes.ts
+++ b/src/interfaces/CommonTypes.ts
@@ -20,7 +20,7 @@ export interface BtnProps {
 
 // Badge.tsx
 export interface BadgeProps {
-  $category?: string
+  $category: string
 }
 
 // Image.tsx
@@ -42,7 +42,7 @@ export interface TierProps {
 // ReportList.tsx
 export interface ReportListProps {
   reportlist: {
-    category: string[]
+    category: string
     reportCapture: string[]
     reportDate: string
     reportId: number

--- a/src/interfaces/UserInfoTypes.ts
+++ b/src/interfaces/UserInfoTypes.ts
@@ -21,4 +21,9 @@ export interface IngameType {
     rank: string
     tier: string
   }
+  reportsData?: {
+    category: string
+    reportCount: number
+    summonerName: string
+  }
 }

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -86,7 +86,13 @@ const UserInfo = () => {
                     {'인게임 정보 보기'}
                   </Button>
                   {toggleIngame && <Portal type={'Ingame'} onclick={toggleIngameHandler} nickname={nickname} />}
-                  <Button size={'l'} color={'basic'} onclick={() => navigate('/report')}>
+                  <Button
+                    size={'l'}
+                    color={'basic'}
+                    onclick={() => {
+                      navigate('/report', { state: { nickname } })
+                    }}
+                  >
                     {'신고하기'}
                   </Button>
                 </UserBtnDiv>

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -38,18 +38,18 @@ const UserInfo = () => {
   useEffect(() => {
     if (data) {
       const userSWord = {
-        기타: data.getCussWordData.categoryCounts.기타,
-        성희롱: data.getCussWordData.categoryCounts.성희롱,
-        쌍욕: data.getCussWordData.categoryCounts.쌍욕,
-        인신공격: data.getCussWordData.categoryCounts.인신공격,
-        패드립: data.getCussWordData.categoryCounts.패드립,
-        혐오성발언: data.getCussWordData.categoryCounts.혐오성발언,
+        기타: data.getCussWordData.categoryCounts.기타 || 0,
+        성희롱: data.getCussWordData.categoryCounts.성희롱 || 0,
+        쌍욕: data.getCussWordData.categoryCounts.쌍욕 || 0,
+        인신공격: data.getCussWordData.categoryCounts.인신공격 || 0,
+        패드립: data.getCussWordData.categoryCounts.패드립 || 0,
+        혐오성발언: data.getCussWordData.categoryCounts.혐오성발언 || 0,
       }
       const userRegion = {
-        아레나: data.Arena.gameCount,
-        자유랭크: data.RANKED_FLEX_SR.gameCount,
-        솔로랭크: data.RANKED_SOLO_5x5.gameCount,
-        TFT: data.RANKED_TFT.gameCount,
+        이벤트게임: data.Event_Game.gameCount || 0,
+        자유랭크: data.RANKED_FLEX_SR.gameCount || 0,
+        솔로랭크: data.RANKED_SOLO_5x5.gameCount || 0,
+        TFT: data.RANKED_TFT.gameCount || 0,
       }
       setSWordData((prev) => ({
         ...prev,
@@ -75,9 +75,9 @@ const UserInfo = () => {
             <InfoSection>
               <div>
                 <UserInfoDiv>
-                  <Image width={100} height={100} $border={5} />
+                  <Image width={100} height={100} $border={5} src={data.profileIconIdUrl} />
                   <div>
-                    <h2>{`TOP ${data.getCussWordData.rank}`}</h2>
+                    <h2>{data.getCussWordData.rank === 0 ? `No Ranking` : `TOP ${data.getCussWordData.rank}`}</h2>
                     <h1>{data.summonerName}</h1>
                   </div>
                 </UserInfoDiv>

--- a/src/style/GlobalStyle.ts
+++ b/src/style/GlobalStyle.ts
@@ -12,6 +12,8 @@ export const GlobalStyle = createGlobalStyle`
   *, *:before, *:after { box-sizing: border-box; }
   html { 
     overflow-y: auto;
+    overflow-x: hidden;
+  
     ::-webkit-scrollbar {
       width: 12px;
       height: 125px;
@@ -21,12 +23,15 @@ export const GlobalStyle = createGlobalStyle`
       background-color: ${({ theme }) => theme.gray.SF};
       border-radius: 6px;
     }
-
+  
     ::-webkit-scrollbar-track {
       background-color: ${({ theme }) => theme.gray.TO};
     }
   }
-  body { min-width: 320px; }
+  body { 
+    min-width: 320px;
+  
+  }
   ol, ul, li { list-style: none; }
   a { text-decoration: none; color: inherit; }
   img { border: 0; vertical-align: middle; }


### PR DESCRIPTION
`공통`
* api response값 변경에 따른 공통 컴포넌트 Badge, Tier 출력 코드 및 값 수정
* GlobalStyle에 overflow-x: hidden 적용하여 불필요한 가로 스크롤 출력 제한
* 공통 Image 컴포넌트에 response로 받은 img src값이 에러일 경우의 onError 코드 추가

`개인`
* Chart 타입 통일에 따른 Chart 파일 공통화하여 병합
* 유저정보, 인게임정보 api 수정분 반영 완료
* 인게임정보 중복되는 코드 추상화 적용하여 리팩토링

`진행사항`
* 페이지네이션 제외 담당 파트 구현 완료 (api 수정 대기 중)
* 로딩스피너 파일 받으면 useQuery loading에 적용 예정