### PR TITLE
Refactor : Header 로그인 체크 로직 수정, 불필요한 color 삭제

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -11,24 +11,24 @@ const Header = () => {
   const navigate = useNavigate()
   const path = useLocation().pathname
 
-  const [isLogin, setIsLogin] = useState(false)
+  const [isLogin, setIsLogin] = useState(!!Cookies.get('accessToken'))
   const [isKorean, setIsKorean] = useState(currentLang.includes('ko'))
 
+  const isLoginChkHandler = () => setIsLogin(!!Cookies.get('accessToken'))
+
   useEffect(() => {
-    const checkLoginStatusHandler = () => {
-      if (Cookies.get('accessToken')) {
-        setIsLogin(true)
-      } else {
-        setIsLogin(false)
-      }
+    isLoginChkHandler()
+    if (!isLogin && path === '/report') {
+      navigate('/afterlogin', { state: { mention: '신고하기' }, replace: true })
+    } else if (!isLogin && (path === '/mypage' || path === '/editinfo' || path === '/myReport')) {
+      navigate('/afterlogin', { state: { mention: '마이페이지' }, replace: true })
     }
-    checkLoginStatusHandler()
   })
 
   const moveToSignOutBtnHandler = () => {
     Cookies.remove('accessToken')
     localStorage.removeItem('nickname')
-    navigate('/')
+    isLoginChkHandler()
   }
 
   const translateBtnHandler = () => {

--- a/src/pages/status/AfterLoginPage.tsx
+++ b/src/pages/status/AfterLoginPage.tsx
@@ -1,14 +1,16 @@
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { styled } from 'styled-components'
 import AfterLogin from '../../assets/afterLogin.svg'
 import { Button } from '../../components/common'
 
-const AfterLoginPage = ({ mention }: { mention?: string }) => {
+const AfterLoginPage = () => {
   const navigate = useNavigate()
+  const { mention } = useLocation().state
 
   const loginPageRouteHandler = () => {
     navigate('/signin')
   }
+
   return (
     <AfterLoginWrap>
       <ImgWrap>

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -23,7 +23,6 @@ const theme = {
   // ${({ theme }) => theme.gray.keyname};
   gray: {
     OS: '#171717',
-    color: '#060606',
     TO: '#212121',
     TT: '#323232',
     TF: '#3F3F3F',


### PR DESCRIPTION
`theme`
- 불필요한 color 삭제

`Header`
- 로그인 체크 true/false에서 !!Cookies.get('accessToken')로 수정
- 비로그인 + 프라이빗 주소값일 경우 afterlogin 랜딩 설정

`AfterLoginPage`
- mention Props -> location.state로 변경